### PR TITLE
Parameterizing tests to run each distance individually

### DIFF
--- a/metriX/statistical_measures.py
+++ b/metriX/statistical_measures.py
@@ -88,7 +88,7 @@ class StatisticalMeasures(ABC):
         """Create an Instance of the statistical distance measure"""
 
     @classmethod
-    def create(cls, *args: Any, **kwargs: Any) -> "RelativeEntropy":
+    def create(cls, *args: Any, **kwargs: Any) -> "StatisticalMeasures":
         """
         Create an instance of the the statistical distance measure.
 
@@ -167,6 +167,7 @@ class StatisticalMeasures(ABC):
 
         """
         return list(cls._registry.values())
+
 
 # --------------------------------------------------------------------------------------------------------------------
 # -------------------------------------------- Relative Entropy Divergence -------------------------------------------


### PR DESCRIPTION
Adding parameterised tests that run a test for each distance function instead of running all in one single function call. Enables to debug each distance function on its own without requiring to running the others.